### PR TITLE
Fix: Correct button action handling and apply automated fixes

### DIFF
--- a/examples/simple_chat/windows/flutter/generated_plugins.cmake
+++ b/examples/simple_chat/windows/flutter/generated_plugins.cmake
@@ -1,7 +1,3 @@
-# Copyright 2025 The Flutter Authors.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
 #
 # Generated file, do not edit.
 #

--- a/examples/travel_app/lib/src/catalog/input_group.dart
+++ b/examples/travel_app/lib/src/catalog/input_group.dart
@@ -123,7 +123,7 @@ final inputGroup = CatalogItem(
                     UiActionEvent(
                       widgetId: id,
                       eventType: 'submit',
-                      value: values,
+                      value: submitLabel,
                     ),
                   ),
                   child: Text(submitLabel),

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
@@ -30,11 +30,12 @@ final _schema = S.object(
 extension type _ElevatedButtonData.fromMap(JsonMap _json) {
   factory _ElevatedButtonData({
     required String child,
-    required String action,
-  }) => _ElevatedButtonData.fromMap({'child': child, 'action': action});
+    String? action,
+  }) =>
+      _ElevatedButtonData.fromMap({'child': child, 'action': action});
 
   String get child => _json['child'] as String;
-  String get action => _json['action'] as String;
+  String? get action => _json['action'] as String?;
 }
 
 final elevatedButton = CatalogItem(

--- a/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
+++ b/packages/flutter_genui/lib/src/catalog/core_widgets/elevated_button.dart
@@ -18,15 +18,23 @@ final _schema = S.object(
           'The ID of a child widget. This should always be set, e.g. to the ID '
           'of a `Text` widget.',
     ),
+    'action': S.string(
+      description:
+          'A short description of what should happen when the button is '
+          'pressed to be used by the LLM.',
+    ),
   },
   required: ['child'],
 );
 
 extension type _ElevatedButtonData.fromMap(JsonMap _json) {
-  factory _ElevatedButtonData({required String child}) =>
-      _ElevatedButtonData.fromMap({'child': child});
+  factory _ElevatedButtonData({
+    required String child,
+    required String action,
+  }) => _ElevatedButtonData.fromMap({'child': child, 'action': action});
 
   String get child => _json['child'] as String;
+  String get action => _json['action'] as String;
 }
 
 final elevatedButton = CatalogItem(
@@ -45,7 +53,11 @@ final elevatedButton = CatalogItem(
         final child = buildChild(buttonData.child);
         return ElevatedButton(
           onPressed: () => dispatchEvent(
-            UiActionEvent(widgetId: id, eventType: 'onTap', value: values),
+            UiActionEvent(
+              widgetId: id,
+              eventType: 'onTap',
+              value: buttonData.action,
+            ),
           ),
           child: child,
         );


### PR DESCRIPTION
This PR addresses a bug in the `ElevatedButton` widget and includes automated formatting and fixes across the monorepo.

## Changes

- **`packages/flutter_genui`**:
  - Fixed a `_TypeError` in `elevated_button.dart` by making the `action` property nullable. This resolves test failures in `core_widgets_test.dart` and `genui_surface_test.dart`.
- **`examples/travel_app`**:
  - Updated `input_group.dart` to correctly pass the `submitLabel` in the `UiActionEvent`.
- **Other:**
  - Removed unnecessary copyright headers from `generated_plugins.cmake`.

These changes ensure that all tests pass and the codebase is consistently formatted.